### PR TITLE
update GitHub Actions workflow to use version 1.0.103 for multi-archi…

### DIFF
--- a/.github/workflows/go.image.multiarch.build.k8s.yml
+++ b/.github/workflows/go.image.multiarch.build.k8s.yml
@@ -10,8 +10,6 @@ permissions:
 
 jobs:
   go-multi-arch-image-build:
-    uses:  tommzn/github-ci/.github/workflows/go.image.multiarch.build.v2.yml@v1.0.102
-    secrets:
-      cr-pat: ${{ secrets.CR_PAT }}
+    uses:  tommzn/github-ci/.github/workflows/go.image.multiarch.build.v2.yml@v1.0.103
     with:
       work-directory: './backend'


### PR DESCRIPTION
This pull request updates the workflow configuration for building multi-architecture Go images in Kubernetes. The most significant change is an upgrade to the reusable workflow version.

Workflow configuration update:

* [`.github/workflows/go.image.multiarch.build.k8s.yml`](diffhunk://#diff-f16616773746b5070bb21e4bf1f2ba409b395d0d24de9d78d7512da6865d2f3eL13-R13): Updated the reusable workflow reference from version `v1.0.102` to `v1.0.103`, which may include bug fixes or improvements from upstream.…tecture image build