### PR TITLE
Update protoc.sh to change gRPC output directory to current directory

### DIFF
--- a/protoc.sh
+++ b/protoc.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-protoc --go_out=. --go-grpc_out=core/proto core/proto/game.proto
+protoc --go_out=. --go-grpc_out=./ core/proto/game.proto


### PR DESCRIPTION
This pull request updates the `protoc.sh` script to fix the output directory for generated gRPC code.

* Build process update:
  * Changed the `--go-grpc_out` argument in `protoc.sh` from `core/proto` to `./` to ensure gRPC code is generated in the correct location.