### PR TITLE
Refactor image build

### DIFF
--- a/.github/workflows/go.image.multiarch.build.k8s.yml
+++ b/.github/workflows/go.image.multiarch.build.k8s.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   go-multi-arch-image-build:
-    uses:  tommzn/github-ci/.github/workflows/go.image.multiarch.build.v2.yml@v1.0.103
+    uses:  tommzn/github-ci/.github/workflows/go.image.multiarch.build.v2.yml@v1.0.104
     with:
       work-directory: './backend'
+      image-suffix: '-backend'

--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -1,19 +1,19 @@
 kind: Deployment
 apiVersion: apps/v1
 metadata:
-  name: de-tommzn-utte-universe
+  name: de-tommzn-utte-universe-backend
   namespace: utte
   labels:
-    app: de-tommzn-utte-universe
+    app: de-tommzn-utte-universe-backend
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: de-tommzn-utte-universe
+      app: de-tommzn-utte-universe-backend
   template:
     metadata:
       labels:
-        app: de-tommzn-utte-universe
+        app: de-tommzn-utte-universe-backend
     spec:
       volumes:
         - name: secret-volume
@@ -70,3 +70,19 @@ spec:
             # expects status code 204
       imagePullSecrets:
         - name: ghcr-credentials
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: de-tommzn-utte-universe-backend
+  namespace: utte
+  labels:
+    app: de-tommzn-utte-universe-backend
+spec:
+  selector:
+    app: de-tommzn-utte-universe-backend
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  type: ClusterIP


### PR DESCRIPTION
This pull request updates the deployment configuration to consistently use the `de-tommzn-utte-universe-backend` identifier and introduces a new Kubernetes service for the backend. It also updates the GitHub Actions workflow to use a newer version and adds an image suffix for clarity.

**Kubernetes resource changes:**

* Renamed the deployment and all associated labels/selectors in `k8s/deployment.yml` from `de-tommzn-utte-universe` to `de-tommzn-utte-universe-backend` for improved naming consistency.
* Added a new `Service` resource in `k8s/deployment.yml` to expose the backend deployment internally within the cluster on port 8080.

**CI/CD workflow updates:**

* Updated the reusable GitHub Actions workflow version from `v1.0.103` to `v1.0.104` in `.github/workflows/go.image.multiarch.build.k8s.yml`.
* Added the `image-suffix: '-backend'` parameter to the workflow for clearer image naming.